### PR TITLE
fix: handle empty INBOX_MSG_IDS array under set -u in fast-checker

### DIFF
--- a/core/scripts/fast-checker.sh
+++ b/core/scripts/fast-checker.sh
@@ -378,7 +378,7 @@ Reply using: bash ../../core/bus/send-message.sh ${FROM} normal '<your reply>' $
     # --- Inject if anything found ---
     if [[ -n "$MESSAGE_BLOCK" ]]; then
         if inject_messages "$MESSAGE_BLOCK"; then
-            for ack_id in "${INBOX_MSG_IDS[@]}"; do
+            for ack_id in "${INBOX_MSG_IDS[@]+"${INBOX_MSG_IDS[@]}"}"; do
                 bash "${BUS_DIR}/ack-inbox.sh" "$ack_id" 2>/dev/null || true
             done
             # Cooldown after injection


### PR DESCRIPTION
## Summary

- Fix crash in `fast-checker.sh` caused by empty bash array expansion under `set -u` (strict mode)
- When a Telegram message arrives but the agent inbox is empty, `INBOX_MSG_IDS` stays as `()` — bash treats `"${ARRAY[@]}"` as unbound, crashing the fast-checker in a restart loop
- Uses the standard bash-safe pattern `${arr[@]+"${arr[@]}"}` which expands to nothing when empty

## Impact

Without this fix, the fast-checker crashes on the **first Telegram message** received and keeps restarting, effectively making the bot unresponsive.

## Test plan

- [ ] Send a Telegram message to the bot when no agent inbox messages exist
- [ ] Verify fast-checker stays alive and processes the message
- [ ] Verify agent inbox messages still get acknowledged when present