### PR TITLE
fix: fast-checker bootstrap detection and empty array crash

### DIFF
--- a/core/scripts/fast-checker.sh
+++ b/core/scripts/fast-checker.sh
@@ -29,8 +29,20 @@ log() {
 
 log "Starting. Waiting for agent to finish bootstrapping..."
 
-# Give the agent time to bootstrap before polling
-sleep 30
+# Wait for Claude Code to be ready before injecting messages.
+# Detects readiness by checking for the "permissions" status bar text
+# in the tmux pane, which only appears once Claude Code's UI is fully
+# initialized. Falls back to 30s fixed wait if the text is never found
+# (e.g., if Claude Code changes its UI in a future version).
+BOOT_TIMEOUT=30
+BOOT_ELAPSED=0
+while [[ ${BOOT_ELAPSED} -lt ${BOOT_TIMEOUT} ]]; do
+    if tmux capture-pane -t "${TMUX_SESSION}:0.0" -p 2>/dev/null | grep -q "permissions"; then
+        break
+    fi
+    sleep 2
+    BOOT_ELAPSED=$((BOOT_ELAPSED + 2))
+done
 
 log "Bootstrap wait complete. Beginning poll loop."
 
@@ -378,7 +390,7 @@ Reply using: bash ../../core/bus/send-message.sh ${FROM} normal '<your reply>' $
     # --- Inject if anything found ---
     if [[ -n "$MESSAGE_BLOCK" ]]; then
         if inject_messages "$MESSAGE_BLOCK"; then
-            for ack_id in "${INBOX_MSG_IDS[@]}"; do
+            for ack_id in "${INBOX_MSG_IDS[@]+"${INBOX_MSG_IDS[@]}"}"; do
                 bash "${BUS_DIR}/ack-inbox.sh" "$ack_id" 2>/dev/null || true
             done
             # Cooldown after injection


### PR DESCRIPTION
## Summary

- Replace fixed 30s bootstrap sleep with active readiness detection — polls tmux for Claude Code's "permissions" status bar text, which only appears once the UI is fully initialized
- Falls back to 30s timeout if the text is never found (future-proofing against UI changes)
- Fix crash under `set -u` when `INBOX_MSG_IDS` is an empty array, using the standard bash-safe expansion pattern `${arr[@]+"${arr[@]}"}`

## Context

The 30s sleep was overly conservative — Claude Code typically boots in 3-5 seconds. The new approach adapts to machine speed and starts polling as soon as possible.

The empty array bug caused the fast-checker to crash and restart in a loop every time a Telegram message arrived without inbox messages, effectively preventing message processing.

## Test plan

- [ ] Restart agent, verify fast-checker starts polling within seconds (not 30s)
- [ ] On a slow machine or cold start, verify it waits appropriately
- [ ] Send a Telegram message — verify it's processed without fast-checker crash
- [ ] Check `fast-checker.log` — no `unbound variable` errors