### PR TITLE
feat: working_directory support for agents

### DIFF
--- a/agents/agent-template/config.json
+++ b/agents/agent-template/config.json
@@ -3,5 +3,6 @@
   "enabled": false,
   "startup_delay": 0,
   "max_session_seconds": 255600,
+  "working_directory": "",
   "crons": []
 }

--- a/core/bus/ack-inbox.sh
+++ b/core/bus/ack-inbox.sh
@@ -16,7 +16,7 @@ if [[ -z "${CRM_ROOT:-}" ]]; then
     CRM_INSTANCE_ID="${CRM_INSTANCE_ID:-default}"
     CRM_ROOT="${HOME}/.claude-remote/${CRM_INSTANCE_ID}"
 fi
-CRM_AGENT_NAME="$(basename "$(pwd)")"
+CRM_AGENT_NAME="${CRM_AGENT_NAME:-$(basename "$(pwd)")}"
 ME="${CRM_AGENT_NAME}"
 
 MSG_ID="${1:-}"

--- a/core/bus/answer-callback.sh
+++ b/core/bus/answer-callback.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 TEMPLATE_ROOT="${CRM_TEMPLATE_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
-CRM_AGENT_NAME="$(basename "$(pwd)")"
+CRM_AGENT_NAME="${CRM_AGENT_NAME:-$(basename "$(pwd)")}"
 ME="${CRM_AGENT_NAME}"
 
 CALLBACK_QUERY_ID="$1"

--- a/core/bus/check-inbox.sh
+++ b/core/bus/check-inbox.sh
@@ -18,7 +18,7 @@ if [[ -z "${CRM_ROOT:-}" ]]; then
     CRM_INSTANCE_ID="${CRM_INSTANCE_ID:-default}"
     CRM_ROOT="${HOME}/.claude-remote/${CRM_INSTANCE_ID}"
 fi
-CRM_AGENT_NAME="$(basename "$(pwd)")"
+CRM_AGENT_NAME="${CRM_AGENT_NAME:-$(basename "$(pwd)")}"
 ME="${CRM_AGENT_NAME}"
 INBOX_DIR="${CRM_ROOT}/inbox/${ME}"
 INFLIGHT_DIR="${CRM_ROOT}/inflight/${ME}"

--- a/core/bus/check-telegram.sh
+++ b/core/bus/check-telegram.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 CRM_ROOT="${CRM_ROOT:-${HOME}/.claude-remote}"
 TEMPLATE_ROOT="${CRM_TEMPLATE_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 # Always detect from cwd
-CRM_AGENT_NAME="$(basename "$(pwd)")"
+CRM_AGENT_NAME="${CRM_AGENT_NAME:-$(basename "$(pwd)")}"
 ME="${CRM_AGENT_NAME}"
 
 # Always source .env to get BOT_TOKEN

--- a/core/bus/edit-message.sh
+++ b/core/bus/edit-message.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 TEMPLATE_ROOT="${CRM_TEMPLATE_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
-CRM_AGENT_NAME="$(basename "$(pwd)")"
+CRM_AGENT_NAME="${CRM_AGENT_NAME:-$(basename "$(pwd)")}"
 ME="${CRM_AGENT_NAME}"
 
 CHAT_ID="$1"

--- a/core/bus/send-message.sh
+++ b/core/bus/send-message.sh
@@ -17,7 +17,7 @@ if [[ -z "${CRM_ROOT:-}" ]]; then
     CRM_ROOT="${HOME}/.claude-remote/${CRM_INSTANCE_ID}"
 fi
 
-CRM_AGENT_NAME="$(basename "$(pwd)")"
+CRM_AGENT_NAME="${CRM_AGENT_NAME:-$(basename "$(pwd)")}"
 FROM="${CRM_AGENT_NAME}"
 
 # Validate agent name to prevent injection

--- a/core/bus/send-telegram.sh
+++ b/core/bus/send-telegram.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 TEMPLATE_ROOT="${CRM_TEMPLATE_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
-CRM_AGENT_NAME="$(basename "$(pwd)")"
+CRM_AGENT_NAME="${CRM_AGENT_NAME:-$(basename "$(pwd)")}"
 ME="${CRM_AGENT_NAME}"
 
 # Parse arguments - handle --image flag

--- a/core/scripts/agent-wrapper.sh
+++ b/core/scripts/agent-wrapper.sh
@@ -97,6 +97,29 @@ if [[ -n "${MODEL}" ]]; then
     MODEL_FLAG="--model ${MODEL}"
 fi
 
+# Working directory override: set "working_directory" in config.json to launch
+# Claude Code in a different project directory. The agent's identity (CLAUDE.md,
+# settings.json, .env) stays centralized here; only the cwd changes.
+WORK_DIR=$(jq -r '.working_directory // empty' "${AGENT_DIR}/config.json" 2>/dev/null || echo "")
+LAUNCH_DIR="${AGENT_DIR}"
+EXTRA_FLAGS=()
+
+if [[ -n "${WORK_DIR}" ]]; then
+    if [[ ! -d "${WORK_DIR}" ]]; then
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ERROR: working_directory '${WORK_DIR}' does not exist" >&2
+        exit 1
+    fi
+    LAUNCH_DIR="${WORK_DIR}"
+    # Inject agent identity into system prompt (since we're not in AGENT_DIR)
+    EXTRA_FLAGS+=(--append-system-prompt-file "${AGENT_DIR}/CLAUDE.md")
+    # Inject agent hooks/permissions from central repo
+    if [[ -f "${AGENT_DIR}/.claude/settings.json" ]]; then
+        EXTRA_FLAGS+=(--settings "${AGENT_DIR}/.claude/settings.json")
+    fi
+    # Give agent access to central repo for bus scripts, config, etc.
+    EXTRA_FLAGS+=(--add-dir "${TEMPLATE_ROOT}")
+fi
+
 # Prompts - two distinct variants based on start mode
 RESTART_NOTIFY="After setting up crons, send a Telegram message to the user saying you are back online, what session this is, and what you are about to work on."
 
@@ -110,12 +133,12 @@ CONTINUE_PROMPT="SESSION CONTINUATION: Your CLI process was restarted with --con
 # Without the marker, launchd respawns always use --continue to preserve conversation history.
 FORCE_FRESH_MARKER="${CRM_ROOT}/state/${AGENT}.force-fresh"
 
-cd "${AGENT_DIR}"
+cd "${LAUNCH_DIR}"
 
 # Determine start mode
 # Check if there's actually a conversation to continue by looking for .jsonl files
-# in Claude's project conversation directory.
-CONV_DIR="${HOME}/.claude/projects/-$(echo "${AGENT_DIR}" | tr '/' '-')"
+# in Claude's project conversation directory (based on the actual launch directory).
+CONV_DIR="${HOME}/.claude/projects/-$(echo "${LAUNCH_DIR}" | tr '/' '-')"
 HAS_CONVERSATION=false
 if [[ -d "${CONV_DIR}" ]] && ls "${CONV_DIR}"/*.jsonl &>/dev/null; then
     HAS_CONVERSATION=true
@@ -132,6 +155,15 @@ else
 fi
 
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Starting ${AGENT} mode=${START_MODE} (session cap: ${MAX_SESSION}s)" >> "${LOG_DIR}/activity.log"
+
+# Register skills/commands as Telegram bot / autocomplete commands
+if [[ -n "${BOT_TOKEN:-}" ]]; then
+    REGISTER_SCRIPT="${TEMPLATE_ROOT}/core/scripts/register-telegram-commands.sh"
+    if [[ -f "${REGISTER_SCRIPT}" ]]; then
+        bash "${REGISTER_SCRIPT}" "${BOT_TOKEN}" "${LAUNCH_DIR}" "${AGENT_DIR}" \
+            >> "${LOG_DIR}/activity.log" 2>&1 || true
+    fi
+fi
 
 # Prevent Mac from sleeping while agent runs
 caffeinate -is -w $$ &
@@ -161,24 +193,32 @@ $(cat "${lf}")
     fi
 fi
 
+# Serialize EXTRA_FLAGS for use in generated scripts and tmux commands
+EXTRA_FLAGS_STR=""
+for flag in "${EXTRA_FLAGS[@]+"${EXTRA_FLAGS[@]}"}"; do
+    EXTRA_FLAGS_STR+=" '${flag}'"
+done
+
 # Build the initial launch command based on start mode
 if [[ "${START_MODE}" == "fresh" ]]; then
     LAUNCHER="${LOG_DIR}/.launch.sh"
     cat > "${LAUNCHER}" << LAUNCH_SCRIPT
 #!/usr/bin/env bash
-cd '${AGENT_DIR}'
+cd '${LAUNCH_DIR}'
 ARGS=(--dangerously-skip-permissions)
 ${MODEL_FLAG:+ARGS+=(--model ${MODEL})}
 LOCAL_FILE="${LOG_DIR}/.local-prompt"
 if [[ -f "\${LOCAL_FILE}" ]]; then
     ARGS+=(--append-system-prompt "\$(cat "\${LOCAL_FILE}")")
 fi
+EXTRA=(${EXTRA_FLAGS_STR})
+ARGS+=("\${EXTRA[@]+"\${EXTRA[@]}"}")
 exec claude "\${ARGS[@]}" '${STARTUP_PROMPT}'
 LAUNCH_SCRIPT
     chmod +x "${LAUNCHER}"
     INITIAL_CMD="bash '${LAUNCHER}'"
 else
-    INITIAL_CMD="cd '${AGENT_DIR}' && claude --continue --dangerously-skip-permissions ${MODEL_FLAG} '${CONTINUE_PROMPT}'"
+    INITIAL_CMD="cd '${LAUNCH_DIR}' && claude --continue --dangerously-skip-permissions ${MODEL_FLAG}${EXTRA_FLAGS_STR} '${CONTINUE_PROMPT}'"
 fi
 
 # Start claude inside a tmux session
@@ -226,7 +266,7 @@ trap graceful_shutdown SIGTERM SIGINT
             fi
 
             tmux send-keys -t "${TMUX_SESSION}:0.0" \
-                "cd '${AGENT_DIR}' && claude --continue --dangerously-skip-permissions ${MODEL_FLAG} '${CONTINUE_PROMPT}'" Enter
+                "cd '${LAUNCH_DIR}' && claude --continue --dangerously-skip-permissions ${MODEL_FLAG}${EXTRA_FLAGS_STR} '${CONTINUE_PROMPT}'" Enter
 
             echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Relaunched ${AGENT} with --continue" >> "${LOG_DIR}/activity.log"
         else

--- a/core/scripts/fast-checker.sh
+++ b/core/scripts/fast-checker.sh
@@ -29,8 +29,20 @@ log() {
 
 log "Starting. Waiting for agent to finish bootstrapping..."
 
-# Give the agent time to bootstrap before polling
-sleep 30
+# Wait for Claude Code to be ready before injecting messages.
+# Detects readiness by checking for the "permissions" status bar text
+# in the tmux pane, which only appears once Claude Code's UI is fully
+# initialized. Falls back to 30s fixed wait if the text is never found
+# (e.g., if Claude Code changes its UI in a future version).
+BOOT_TIMEOUT=30
+BOOT_ELAPSED=0
+while [[ ${BOOT_ELAPSED} -lt ${BOOT_TIMEOUT} ]]; do
+    if tmux capture-pane -t "${TMUX_SESSION}:0.0" -p 2>/dev/null | grep -q "permissions"; then
+        break
+    fi
+    sleep 2
+    BOOT_ELAPSED=$((BOOT_ELAPSED + 2))
+done
 
 log "Bootstrap wait complete. Beginning poll loop."
 
@@ -378,7 +390,7 @@ Reply using: bash ../../core/bus/send-message.sh ${FROM} normal '<your reply>' $
     # --- Inject if anything found ---
     if [[ -n "$MESSAGE_BLOCK" ]]; then
         if inject_messages "$MESSAGE_BLOCK"; then
-            for ack_id in "${INBOX_MSG_IDS[@]}"; do
+            for ack_id in "${INBOX_MSG_IDS[@]+"${INBOX_MSG_IDS[@]}"}"; do
                 bash "${BUS_DIR}/ack-inbox.sh" "$ack_id" 2>/dev/null || true
             done
             # Cooldown after injection

--- a/core/scripts/register-telegram-commands.sh
+++ b/core/scripts/register-telegram-commands.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# register-telegram-commands.sh - Register skills/commands as Telegram bot / autocomplete
+#
+# Scans directories for Claude Code skills and commands, parses their YAML
+# frontmatter, and registers user-invocable ones via Telegram's setMyCommands API.
+#
+# Usage: register-telegram-commands.sh <bot_token> <scan_dir> [<scan_dir2> ...]
+#
+# Scanned locations (per directory):
+#   .claude/commands/*.md     - Claude Code slash commands
+#   .claude/skills/*/SKILL.md - Claude Code skills
+#   skills/*/SKILL.md         - Legacy/custom skills
+#
+# Frontmatter fields used:
+#   name              - becomes the /command name (required or derived from filename)
+#   description       - shown in Telegram autocomplete (max 256 chars)
+#   user-invocable    - when "false", skill is excluded from registration
+
+set -euo pipefail
+
+BOT_TOKEN="$1"
+shift
+SCAN_DIRS=("$@")
+
+if [[ -z "${BOT_TOKEN}" ]]; then
+    echo "ERROR: BOT_TOKEN required" >&2
+    exit 1
+fi
+
+# --- Frontmatter parser ---
+# Reads YAML frontmatter from a markdown file. Handles single-line values,
+# quoted strings, and YAML multi-line indicators (>-, >, |-, |).
+# Output: name|description|user-invocable (pipe-delimited)
+parse_frontmatter() {
+    local file="$1"
+    local in_frontmatter=false
+    local name="" description="" user_invocable="true"
+    local reading_multiline="" multiline_value=""
+
+    while IFS= read -r line; do
+        # Detect frontmatter boundaries
+        if [[ "${line}" == "---" ]]; then
+            if [[ "${in_frontmatter}" == "true" ]]; then
+                break
+            fi
+            in_frontmatter=true
+            continue
+        fi
+        [[ "${in_frontmatter}" == "true" ]] || continue
+
+        # Multi-line continuation: indented lines belong to the previous field
+        if [[ -n "${reading_multiline}" && "${line}" =~ ^[[:space:]] ]]; then
+            local trimmed
+            trimmed=$(echo "${line}" | sed 's/^[[:space:]]*//')
+            multiline_value="${multiline_value} ${trimmed}"
+            continue
+        elif [[ -n "${reading_multiline}" ]]; then
+            eval "${reading_multiline}=\"\${multiline_value}\""
+            reading_multiline=""
+            multiline_value=""
+        fi
+
+        # Parse known fields
+        case "${line}" in
+            name:*)
+                name=$(echo "${line#name:}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^"//;s/"$//')
+                ;;
+            description:*)
+                local val
+                val=$(echo "${line#description:}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^"//;s/"$//')
+                if [[ "${val}" =~ ^[\>\|]-?$ ]]; then
+                    reading_multiline="description"
+                    multiline_value=""
+                else
+                    description="${val}"
+                fi
+                ;;
+            user-invocable:*)
+                user_invocable=$(echo "${line#user-invocable:}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                ;;
+        esac
+    done < "$file"
+
+    # Flush remaining multi-line value
+    if [[ -n "${reading_multiline}" ]]; then
+        eval "${reading_multiline}=\"\${multiline_value}\""
+    fi
+
+    description=$(echo "${description}" | sed 's/^[[:space:]]*//')
+    echo "${name}|${description}|${user_invocable}"
+}
+
+# --- Collect skill files from all scan directories ---
+collect_skill_files() {
+    local dir="$1"
+    local paths=(
+        "${dir}/.claude/commands/*.md"
+        "${dir}/.claude/skills/*/SKILL.md"
+        "${dir}/skills/*/SKILL.md"
+    )
+    for pattern in "${paths[@]}"; do
+        for file in ${pattern}; do
+            [[ -f "${file}" ]] && echo "${file}"
+        done
+    done
+}
+
+# --- Derive command name from file path ---
+# SKILL.md -> use parent directory name; *.md -> use filename without extension
+derive_name() {
+    local file="$1"
+    if [[ "$(basename "${file}")" == "SKILL.md" ]]; then
+        basename "$(dirname "${file}")"
+    else
+        basename "${file}" .md
+    fi
+}
+
+# --- Sanitize name for Telegram ---
+# Telegram commands: lowercase, a-z 0-9 underscore only, max 32 chars
+sanitize_command() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' | tr '-' '_' | sed 's/[^a-z0-9_]//g' | cut -c1-32
+}
+
+# --- Build commands JSON array ---
+COMMANDS_JSON="[]"
+SEEN=""
+
+for dir in "${SCAN_DIRS[@]}"; do
+    [[ -d "${dir}" ]] || continue
+
+    while IFS= read -r file; do
+        IFS='|' read -r name desc invocable <<< "$(parse_frontmatter "${file}")"
+
+        [[ -z "${name}" ]] && name=$(derive_name "${file}")
+        [[ -z "${desc}" ]] && desc="Skill: ${name}"
+        [[ "${invocable}" == "false" ]] && continue
+
+        cmd=$(sanitize_command "${name}")
+        [[ -z "${cmd}" ]] && continue
+
+        # Deduplicate (first occurrence wins)
+        echo "${SEEN}" | grep -q "^${cmd}$" && continue
+        SEEN="${SEEN}${cmd}"$'\n'
+
+        # jq handles all JSON escaping; truncate description to Telegram's limit
+        COMMANDS_JSON=$(echo "${COMMANDS_JSON}" | jq \
+            --arg cmd "${cmd}" \
+            --arg desc "$(echo "${desc}" | cut -c1-256)" \
+            '. + [{"command": $cmd, "description": $desc}]')
+    done <<< "$(collect_skill_files "${dir}")"
+done
+
+# --- Register with Telegram ---
+COUNT=$(echo "${COMMANDS_JSON}" | jq 'length')
+
+if [[ "${COUNT}" -eq 0 ]]; then
+    echo "No commands found to register"
+    exit 0
+fi
+
+PAYLOAD=$(jq -n --argjson cmds "${COMMANDS_JSON}" '{"commands": $cmds}')
+RESPONSE=$(curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/setMyCommands" \
+    -H "Content-Type: application/json" \
+    -d "${PAYLOAD}")
+
+if echo "${RESPONSE}" | jq -e '.ok == true' > /dev/null 2>&1; then
+    echo "Registered ${COUNT} Telegram commands"
+else
+    echo "WARNING: Failed to register Telegram commands: ${RESPONSE}" >&2
+fi


### PR DESCRIPTION
## Summary

- Agents can now run in a different project directory by setting `working_directory` in `config.json`
- Agent identity (CLAUDE.md, hooks, .env, logs) stays centralized in this repo
- When set, the wrapper injects identity via `--append-system-prompt-file`, hooks via `--settings`, and central repo access via `--add-dir`
- Bus scripts now use the exported `CRM_AGENT_NAME` instead of `basename $(pwd)`, which broke when cwd was a different project
- On boot, scans launch dir and agent dir for skills/commands and registers them as Telegram `/` autocomplete via `setMyCommands` API
- Replaces fast-checker's fixed 30s bootstrap sleep with active readiness detection (polls for Claude Code's permission bar)
- Fixes fast-checker empty `INBOX_MSG_IDS` array crash under `set -u`

## Files changed

| File | Change |
|------|--------|
| `agents/agent-template/config.json` | Added `working_directory` field |
| `core/scripts/agent-wrapper.sh` | working_directory logic, EXTRA_FLAGS, Telegram command registration |
| `core/scripts/register-telegram-commands.sh` | **New** — parses skill frontmatter, registers with Telegram API |
| `core/scripts/fast-checker.sh` | Bootstrap readiness detection + empty array fix |
| `core/bus/*.sh` (7 files) | Use exported `CRM_AGENT_NAME` with fallback |

## Test plan

- [ ] Set `working_directory` to a valid project path, restart agent
- [ ] Verify Claude Code launches in that directory (`pwd` in tmux)
- [ ] Verify Telegram messages arrive and agent responds
- [ ] Verify `/` in Telegram shows autocomplete for skills from both directories
- [ ] Remove `working_directory` — verify unchanged behavior
- [ ] Set to non-existent path — verify clean error in logs