### PR TITLE
fix: preserve existing .env on reinstall (closes #8)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,15 +77,12 @@ cat > "${CRM_ROOT}/config/enabled-agents.json" << 'EOF'
 {}
 EOF
 
-# Write .env to repo root
-cat > "${TEMPLATE_ROOT}/.env" << EOF
+# Write .env to repo root (only if it doesn't already exist, to preserve custom config)
+if [[ ! -f "${TEMPLATE_ROOT}/.env" ]]; then
+    cat > "${TEMPLATE_ROOT}/.env" << EOF
 CRM_INSTANCE_ID=${CRM_INSTANCE_ID}
 CRM_ROOT=${CRM_ROOT}
 EOF
-
-# Copy .env.example if .env doesn't already exist
-if [[ ! -f "${TEMPLATE_ROOT}/.env" ]]; then
-    cp "${TEMPLATE_ROOT}/.env.example" "${TEMPLATE_ROOT}/.env"
 fi
 
 # Make all scripts executable


### PR DESCRIPTION
## Summary

Fixes the dead code reported in #8.

The `.env.example` fallback block (lines 87–89) could never execute — `.env` was unconditionally written at line 81, so the existence check always evaluated to false.

**Fix (Option B from the issue):** Guard the entire write with the existence check, so a pre-existing `.env` (e.g. custom `CRM_INSTANCE_ID`) is preserved on reinstall rather than silently overwritten.

## Change

```bash
# Before (dead code):
cat > "${TEMPLATE_ROOT}/.env" << EOF   # always writes
...
if [[ ! -f "${TEMPLATE_ROOT}/.env" ]]; then   # always false
    cp "${TEMPLATE_ROOT}/.env.example" "${TEMPLATE_ROOT}/.env"
fi

# After:
if [[ ! -f "${TEMPLATE_ROOT}/.env" ]]; then   # only write if absent
    cat > "${TEMPLATE_ROOT}/.env" << EOF
    ...
fi
```

Low-risk change — behavior is identical on a fresh install. On reinstall (which the script currently blocks anyway via the `CRM_ROOT` existence check), this would now preserve custom config rather than overwrite it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)