### PR TITLE
fix: remove DEBUG xxd log from fast-checker

### DIFF
--- a/core/scripts/fast-checker.sh
+++ b/core/scripts/fast-checker.sh
@@ -192,8 +192,6 @@ while true; do
 
                 # === AskUserQuestion handlers ===
                 ASK_STATE="/tmp/crm-ask-state-${AGENT}.json"
-                log "DEBUG callback_data='${DATA}' hex=$(printf '%s' "$DATA" | xxd -p | head -c 60)"
-
                 # Single-select: askopt_{questionIdx}_{optionIdx}
                 if [[ "$DATA" =~ ^askopt_([0-9]+)_([0-9]+)$ ]]; then
                     Q_IDX="${BASH_REMATCH[1]}"


### PR DESCRIPTION
## Summary
- Removed debug log line that ran `xxd` on every Telegram callback
- `xxd` is not a declared dependency and fails on some Linux distros
- Eliminates log pollution from hex dumps on every button press

Fixes #7