### PR TITLE
fix: preserve existing .env on reinstall, remove dead code

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,15 +77,12 @@ cat > "${CRM_ROOT}/config/enabled-agents.json" << 'EOF'
 {}
 EOF
 
-# Write .env to repo root
-cat > "${TEMPLATE_ROOT}/.env" << EOF
+# Write .env to repo root (only if it doesn't already exist, to preserve custom config)
+if [[ ! -f "${TEMPLATE_ROOT}/.env" ]]; then
+    cat > "${TEMPLATE_ROOT}/.env" << EOF
 CRM_INSTANCE_ID=${CRM_INSTANCE_ID}
 CRM_ROOT=${CRM_ROOT}
 EOF
-
-# Copy .env.example if .env doesn't already exist
-if [[ ! -f "${TEMPLATE_ROOT}/.env" ]]; then
-    cp "${TEMPLATE_ROOT}/.env.example" "${TEMPLATE_ROOT}/.env"
 fi
 
 # Make all scripts executable


### PR DESCRIPTION
## Summary
- Wrapped .env write in existence check so reinstalls preserve custom config
- Removed unreachable .env.example copy block (dead code)
- Same approach as community PR #18 by @noogalabs

## Test plan
- [ ] Fresh install creates .env normally
- [ ] Reinstall preserves existing .env

Fixes #8