### PR TITLE
fix: permission messages use code blocks instead of broken escape_md

### DIFF
--- a/core/bus/hook-permission-telegram.sh
+++ b/core/bus/hook-permission-telegram.sh
@@ -70,16 +70,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Escape markdown special chars for Telegram
-escape_md() {
-    echo "$1" | sed 's/[_*`\[]/\\&/g'
+# Sanitize text for Telegram code blocks (escape triple backticks)
+sanitize_code_block() {
+    echo "$1" | sed "s/\`\`\`/\`\`\\\\\`/g"
 }
 
 MESSAGE="PERMISSION REQUEST
-Agent: $(escape_md "${AGENT}")
-Tool: $(escape_md "${TOOL_NAME}")
+Agent: ${AGENT}
+Tool: ${TOOL_NAME}
 
-$(escape_md "${TOOL_SUMMARY}")"
+\`\`\`
+$(sanitize_code_block "${TOOL_SUMMARY}")
+\`\`\`"
 
 # Truncate if over Telegram's 4096 char limit
 if [[ ${#MESSAGE} -gt 3800 ]]; then


### PR DESCRIPTION
## Summary
- Replaced `escape_md` with code block wrapping for tool summaries
- `escape_md` was broken: regular Markdown doesn't support backslash escaping
- Code blocks neutralize all special chars and display file paths/commands in monospace

## Test plan
- [ ] Trigger a permission request for an Edit on a file with underscores in path
- [ ] Verify message displays cleanly in Telegram with monospace formatting
- [ ] Verify Approve/Deny buttons still work

Fixes #9