### PR TITLE
feat: add document, audio, voice, and video_note receiving

### DIFF
--- a/core/bus/check-telegram.sh
+++ b/core/bus/check-telegram.sh
@@ -96,6 +96,127 @@ if [[ "${MSG_COUNT}" -gt 0 ]]; then
         file_id: (.message.photo | last | .file_id)
     }')
 
+    # Handle document messages: download and output with local path
+    while IFS= read -r doc_msg; do
+        CHAT_ID_VAL=$(echo "${doc_msg}" | jq -r '.chat_id')
+        FROM_VAL=$(echo "${doc_msg}" | jq -r '.from')
+        DATE_VAL=$(echo "${doc_msg}" | jq -r '.date')
+        CAPTION_VAL=$(echo "${doc_msg}" | jq -r '.caption // ""')
+        FILE_ID=$(echo "${doc_msg}" | jq -r '.file_id')
+        FILE_NAME=$(echo "${doc_msg}" | jq -r '.file_name')
+
+        FILE_RESPONSE=$(telegram_api_get "getFile?file_id=${FILE_ID}" 2>/dev/null || echo '{"ok":false}')
+        FILE_PATH=$(echo "${FILE_RESPONSE}" | jq -r '.result.file_path // empty')
+
+        if [[ -n "${FILE_PATH}" ]]; then
+            LOCAL_FILE="${IMAGE_DIR}/${FILE_NAME}"
+            telegram_file_download "${FILE_PATH}" "${LOCAL_FILE}" 2>/dev/null || true
+
+            jq -nc \
+                --arg chat_id "${CHAT_ID_VAL}" \
+                --arg from "${FROM_VAL}" \
+                --arg caption "${CAPTION_VAL}" \
+                --argjson date "${DATE_VAL}" \
+                --arg file_path "${LOCAL_FILE}" \
+                --arg file_name "${FILE_NAME}" \
+                '{chat_id: ($chat_id | tonumber), from: $from, text: $caption, file_path: $file_path, file_name: $file_name, date: $date, type: "document"}'
+        fi
+    done < <(echo "${MESSAGES}" | jq -c '.[] | select(.message.document) | {
+        chat_id: .message.chat.id,
+        from: .message.from.first_name,
+        caption: (.message.caption // ""),
+        date: .message.date,
+        file_id: .message.document.file_id,
+        file_name: .message.document.file_name
+    }')
+
+    # Handle audio messages: download and output with local path
+    while IFS= read -r audio_msg; do
+        CHAT_ID_VAL=$(echo "${audio_msg}" | jq -r '.chat_id')
+        FROM_VAL=$(echo "${audio_msg}" | jq -r '.from')
+        DATE_VAL=$(echo "${audio_msg}" | jq -r '.date')
+        FILE_ID=$(echo "${audio_msg}" | jq -r '.file_id')
+        FILE_NAME=$(echo "${audio_msg}" | jq -r '.file_name')
+
+        FILE_RESPONSE=$(telegram_api_get "getFile?file_id=${FILE_ID}" 2>/dev/null || echo '{"ok":false}')
+        FILE_PATH=$(echo "${FILE_RESPONSE}" | jq -r '.result.file_path // empty')
+
+        if [[ -n "${FILE_PATH}" ]]; then
+            LOCAL_FILE="${IMAGE_DIR}/${FILE_NAME}"
+            telegram_file_download "${FILE_PATH}" "${LOCAL_FILE}" 2>/dev/null || true
+
+            jq -nc \
+                --arg chat_id "${CHAT_ID_VAL}" \
+                --arg from "${FROM_VAL}" \
+                --argjson date "${DATE_VAL}" \
+                --arg file_path "${LOCAL_FILE}" \
+                --arg file_name "${FILE_NAME}" \
+                '{chat_id: ($chat_id | tonumber), from: $from, text: "", file_path: $file_path, file_name: $file_name, date: $date, type: "audio"}'
+        fi
+    done < <(echo "${MESSAGES}" | jq -c '.[] | select(.message.audio) | {
+        chat_id: .message.chat.id,
+        from: .message.from.first_name,
+        date: .message.date,
+        file_id: .message.audio.file_id,
+        file_name: (.message.audio.file_name // ("audio_" + (.message.date | tostring) + ".ogg"))
+    }')
+
+    # Handle voice messages: download and output with local path
+    while IFS= read -r voice_msg; do
+        CHAT_ID_VAL=$(echo "${voice_msg}" | jq -r '.chat_id')
+        FROM_VAL=$(echo "${voice_msg}" | jq -r '.from')
+        DATE_VAL=$(echo "${voice_msg}" | jq -r '.date')
+        FILE_ID=$(echo "${voice_msg}" | jq -r '.file_id')
+
+        FILE_RESPONSE=$(telegram_api_get "getFile?file_id=${FILE_ID}" 2>/dev/null || echo '{"ok":false}')
+        FILE_PATH=$(echo "${FILE_RESPONSE}" | jq -r '.result.file_path // empty')
+
+        if [[ -n "${FILE_PATH}" ]]; then
+            LOCAL_FILE="${IMAGE_DIR}/voice_${DATE_VAL}.ogg"
+            telegram_file_download "${FILE_PATH}" "${LOCAL_FILE}" 2>/dev/null || true
+
+            jq -nc \
+                --arg chat_id "${CHAT_ID_VAL}" \
+                --arg from "${FROM_VAL}" \
+                --argjson date "${DATE_VAL}" \
+                --arg file_path "${LOCAL_FILE}" \
+                '{chat_id: ($chat_id | tonumber), from: $from, text: "", file_path: $file_path, date: $date, type: "voice"}'
+        fi
+    done < <(echo "${MESSAGES}" | jq -c '.[] | select(.message.voice) | {
+        chat_id: .message.chat.id,
+        from: .message.from.first_name,
+        date: .message.date,
+        file_id: .message.voice.file_id
+    }')
+
+    # Handle video_note messages (round video): download and output with local path
+    while IFS= read -r vnote_msg; do
+        CHAT_ID_VAL=$(echo "${vnote_msg}" | jq -r '.chat_id')
+        FROM_VAL=$(echo "${vnote_msg}" | jq -r '.from')
+        DATE_VAL=$(echo "${vnote_msg}" | jq -r '.date')
+        FILE_ID=$(echo "${vnote_msg}" | jq -r '.file_id')
+
+        FILE_RESPONSE=$(telegram_api_get "getFile?file_id=${FILE_ID}" 2>/dev/null || echo '{"ok":false}')
+        FILE_PATH=$(echo "${FILE_RESPONSE}" | jq -r '.result.file_path // empty')
+
+        if [[ -n "${FILE_PATH}" ]]; then
+            LOCAL_FILE="${IMAGE_DIR}/videonote_${DATE_VAL}.mp4"
+            telegram_file_download "${FILE_PATH}" "${LOCAL_FILE}" 2>/dev/null || true
+
+            jq -nc \
+                --arg chat_id "${CHAT_ID_VAL}" \
+                --arg from "${FROM_VAL}" \
+                --argjson date "${DATE_VAL}" \
+                --arg file_path "${LOCAL_FILE}" \
+                '{chat_id: ($chat_id | tonumber), from: $from, text: "", file_path: $file_path, date: $date, type: "video_note"}'
+        fi
+    done < <(echo "${MESSAGES}" | jq -c '.[] | select(.message.video_note) | {
+        chat_id: .message.chat.id,
+        from: .message.from.first_name,
+        date: .message.date,
+        file_id: .message.video_note.file_id
+    }')
+
     # Output callback queries (inline button presses)
     echo "${MESSAGES}" | jq -c '.[] | select(.callback_query) | {
         chat_id: .callback_query.message.chat.id,

--- a/core/scripts/fast-checker.sh
+++ b/core/scripts/fast-checker.sh
@@ -335,6 +335,35 @@ local_file: ${IMAGE_PATH}
 Reply using: bash ../../core/bus/send-telegram.sh ${CHAT_ID} \"<your reply>\"
 
 "
+            elif [[ "$TYPE" == "document" ]]; then
+                DOC_PATH=$(echo "$line" | jq -r '.file_path // ""' 2>/dev/null || echo "")
+                DOC_NAME=$(echo "$line" | jq -r '.file_name // ""' 2>/dev/null || echo "")
+                MESSAGE_BLOCK+="=== TELEGRAM DOCUMENT from ${FROM} (chat_id:${CHAT_ID}) ===
+caption:
+\`\`\`
+${TEXT}
+\`\`\`
+local_file: ${DOC_PATH}
+file_name: ${DOC_NAME}
+Reply using: bash ../../core/bus/send-telegram.sh ${CHAT_ID} \"<your reply>\"
+
+"
+            elif [[ "$TYPE" == "voice" || "$TYPE" == "audio" ]]; then
+                AUDIO_PATH=$(echo "$line" | jq -r '.file_path // ""' 2>/dev/null || echo "")
+                AUDIO_NAME=$(echo "$line" | jq -r '.file_name // ""' 2>/dev/null || echo "")
+                MESSAGE_BLOCK+="=== TELEGRAM ${TYPE^^} from ${FROM} (chat_id:${CHAT_ID}) ===
+local_file: ${AUDIO_PATH}
+file_name: ${AUDIO_NAME}
+Reply using: bash ../../core/bus/send-telegram.sh ${CHAT_ID} \"<your reply>\"
+
+"
+            elif [[ "$TYPE" == "video_note" ]]; then
+                VIDEO_PATH=$(echo "$line" | jq -r '.file_path // ""' 2>/dev/null || echo "")
+                MESSAGE_BLOCK+="=== TELEGRAM VIDEO NOTE from ${FROM} (chat_id:${CHAT_ID}) ===
+local_file: ${VIDEO_PATH}
+Reply using: bash ../../core/bus/send-telegram.sh ${CHAT_ID} \"<your reply>\"
+
+"
             else
                 # Built-in CLI commands: inject raw so they trigger directly
                 if [[ "$TEXT" =~ ^/(compact|clear|help|cost|login|logout|status|doctor|config|bug|init|review|fast|slow)$ ]]; then


### PR DESCRIPTION
## Summary
Extends Telegram message handling to support all common file types beyond photos.

### New message types
| Type | Source | Download Format |
|------|--------|-----------------|
| document | Any file attachment | Original filename |
| audio | Music files | Original or generated name |
| voice | Voice messages | .ogg |
| video_note | Round video messages | .mp4 |

### Files changed
- `core/bus/check-telegram.sh` — 4 new handler loops following the photo pattern
- `core/scripts/fast-checker.sh` — 4 new injection block types for the agent session

### How it works
Each handler: extract file_id from Telegram update → getFile API → download to local dir → output JSON with local_file path → fast-checker injects into Claude session.

## Test plan
- [ ] Send a document (PDF, txt) to agent bot, verify download + injection
- [ ] Send an audio file, verify download
- [ ] Send a voice message, verify download
- [ ] Send a video note (round video), verify download
- [ ] Verify existing photo + text + callback handling unchanged