### PR TITLE
fix: multiple photos in media groups overwrite each other

### DIFF
--- a/core/bus/check-telegram.sh
+++ b/core/bus/check-telegram.sh
@@ -77,7 +77,9 @@ if [[ "${MSG_COUNT}" -gt 0 ]]; then
         FILE_PATH=$(echo "${FILE_RESPONSE}" | jq -r '.result.file_path // empty')
 
         if [[ -n "${FILE_PATH}" ]]; then
-            LOCAL_FILE="${IMAGE_DIR}/${DATE_VAL}.jpg"
+            # Use unique suffix from file_path to prevent overwrite in media groups
+            UNIQUE_SUFFIX=$(echo "${FILE_PATH}" | sed 's|.*/||;s|\..*||' | tail -c 12)
+            LOCAL_FILE="${IMAGE_DIR}/${DATE_VAL}_${UNIQUE_SUFFIX}.jpg"
             telegram_file_download "${FILE_PATH}" "${LOCAL_FILE}" 2>/dev/null || true
 
             jq -nc \


### PR DESCRIPTION
## Summary
Photos in Telegram media groups (multiple photos in one message) all get the same filename and overwrite each other. Uses unique hash from Telegram file_path for distinct filenames.

## Tested
Sent 4-photo media group → all 4 saved as separate files with unique names.

## Test plan
- [ ] Send 1 photo — saves normally
- [ ] Send 4 photos as media group — all 4 save as separate files
- [ ] Verify agent receives all 4 photo injection blocks